### PR TITLE
move fields to required

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Required:
   services. This may also be set using the `EXOSCALE_API_SECRET`
   environmental variable.
 
+- `api_endpoint` (string) - The API endpoint used to communicate with the
+  Exoscale API. Defaults to `https://api.exoscale.com/v1`.
+
+- `sos_endpoint` (string) - The endpoint used to communicate with SOS.
+  Defaults to `https://sos-<template_zone>.exo.io`.
+
 - `image_bucket` (string) - The name of the bucket in which to upload the
   template image to SOS. The bucket must exist when the post-processor is
   run.
@@ -53,18 +59,12 @@ Required:
 
 - `template_name` (string) - The name to be used for registering the template.
 
-### Optional parameters
-
-- `api_endpoint` (string) - The API endpoint used to communicate with the
-  Exoscale API. Defaults to `https://api.exoscale.com/v1`.
-
-- `sos_endpoint` (string) - The endpoint used to communicate with SOS.
-  Defaults to `https://sos-<template_zone>.exo.io`.
-
 - `template_description` (string) - The description of the registered template.
 
 - `template_username` (string) - An optional username to be used to log into
   Compute instances using this template.
+
+### Optional parameters
 
 - `template_boot_mode` (string) - The template boot mode. Supported values: `legacy` (default), `uefi`.
 


### PR DESCRIPTION
Move the following fields to required arguments (according to https://github.com/hashicorp/packer/blob/master/post-processor/exoscale-import/post-processor.go).

api_endpoint
sos_endpoint
template_description
template_username (not in packer required list, but importer complains if not there).